### PR TITLE
fix: use `.mjs` as file extension for esm modules

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -8,6 +8,7 @@ build({
   format: 'esm',
   target: 'esnext',
   platform: 'neutral',
+  outfile: 'index.mjs',
   treeShaking: true,
 });
 

--- a/build.ts
+++ b/build.ts
@@ -8,7 +8,7 @@ build({
   format: 'esm',
   target: 'esnext',
   platform: 'neutral',
-  outfile: 'index.mjs',
+  outExtension: { '.js': '.mjs' },
   treeShaking: true,
 });
 


### PR DESCRIPTION
nodejs enforces that if package.json doesn't use `"type": "module"`, then in order for a module to be imported as a esm module it must have an `.mjs` file extension.
https://nodejs.org/dist/latest-v18.x/docs/api/packages.html#packagejson-and-file-extensions